### PR TITLE
fix: Use `collections.abc` instead of `collections`

### DIFF
--- a/target_sqlite/utils/singer_target_utils.py
+++ b/target_sqlite/utils/singer_target_utils.py
@@ -1,8 +1,8 @@
-import collections
 import inflection
 import itertools
 import logging
 import re
+from collections.abc import MutableMapping
 
 from sqlalchemy import MetaData, Table, Column
 from sqlalchemy.types import TIMESTAMP, Float, String, BigInteger, Boolean
@@ -78,11 +78,11 @@ def flatten_record(d, schema, parent_key=[], sep="__"):
             # If the attribute name (new_key) is defined in the schema
             # Then stop un-nesting and store its values as they are even if
             #  it is an object
-            if isinstance(v, collections.MutableMapping) or type(v) is list:
+            if isinstance(v, MutableMapping) or type(v) is list:
                 items.append((new_key, str(v)))
             else:
                 items.append((new_key, v))
-        elif isinstance(v, collections.MutableMapping):
+        elif isinstance(v, MutableMapping):
             items.extend(flatten_record(v, schema, parent_key + [k], sep=sep).items())
         else:
             items.append((new_key, str(v) if type(v) is list else v))


### PR DESCRIPTION
https://docs.python.org/3.9/library/collections.html

> Deprecated since version 3.3, will be removed in version 3.10: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.9.