### PR TITLE
chore: Drop Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.7"
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,21 +4,19 @@ requires = ["hatchling"]
 
 [project]
 name = "target-sqlite"
-version = "0.5.1"
+version = "0.6.0"
 keywords = ["singer-io", "meltano", "elt", "sqlite", "singer-tap"]
 readme = "README.md"
 license.file = "LICENSE"
 maintainers = [{ name = "Meltano", email = "hello@meltano.com" }]
 authors = [{ name = "Meltano", email = "hello@meltano.com" }]
 description = "Singer.io target for importing data to SQLite"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Both of these version of Python have reached end-of-life. Python 3.7 is no longer supported by the `setup-python` GitHub Action.